### PR TITLE
fix unable to exit create account

### DIFF
--- a/capstone/src/main/java/capstone/Views/TellerCreateAccountView.java
+++ b/capstone/src/main/java/capstone/Views/TellerCreateAccountView.java
@@ -50,7 +50,7 @@ public class TellerCreateAccountView extends View {
 
       int continue_checker = Helper.continue_checker();
       if (continue_checker == 1) {
-        continue;
+        break;
       }
     }
   }


### PR DESCRIPTION
The return statement from the continue checker was wrongly written